### PR TITLE
Fix invalid last member on removeMember

### DIFF
--- a/src/RapidJSONAdapter/JSONValue.cpp
+++ b/src/RapidJSONAdapter/JSONValue.cpp
@@ -261,10 +261,25 @@ namespace systelab { namespace json { namespace rapidjson {
 
 	void JSONValue::removeMember(const std::string& name)
 	{
+		if (m_value.MemberCount() == 0)
+		{
+			return;
+		}
+
 		loadObjectMembers();
+
+		{
+			/*RapidJSON's RemoveMember() swaps JSONValue element between the element to be removed and its last element. 
+			* This modification swaps elements beforehand so after RemoveMember() is called the last element is not lost*/
+
+			auto end = --(m_value.MemberEnd());
+			auto lastName = end->name.GetString();
+			m_objectMembers.find(name)->second.swap(m_objectMembers.find(lastName)->second);
+		}
 
 		m_value.RemoveMember(name);
 		m_objectMembers.erase(name);
+
 	}
 
 	unsigned int JSONValue::getArrayValueCount() const

--- a/src/RapidJSONAdapter/JSONValue.cpp
+++ b/src/RapidJSONAdapter/JSONValue.cpp
@@ -272,8 +272,8 @@ namespace systelab { namespace json { namespace rapidjson {
 			/*RapidJSON's RemoveMember() swaps JSONValue element between the element to be removed and its last element. 
 			* This modification swaps elements beforehand so after RemoveMember() is called the last element is not lost*/
 
-			auto end = --(m_value.MemberEnd());
-			auto lastName = end->name.GetString();
+			auto last = --(m_value.MemberEnd());
+			auto lastName = last->name.GetString();
 			m_objectMembers.find(name)->second.swap(m_objectMembers.find(lastName)->second);
 		}
 

--- a/test/RapidJSONAdapterTest/Tests/JSONValueRemoveTest.cpp
+++ b/test/RapidJSONAdapterTest/Tests/JSONValueRemoveTest.cpp
@@ -1,53 +1,55 @@
 #include "stdafx.h"
-#include "RapidJSONAdapter/JSONAdapter.h"
 
+#include "RapidJSONAdapter/JSONAdapter.h"
 #include "RapidJSONAdapter/JSONDocument.h"
 #include "RapidJSONAdapter/JSONValue.h"
 
-#include "JSONAdapterTestUtilities/JSONAdapterUtilities.h"
-#include "JSONAdapterTestUtilities/Mocks/MockJSONDocument.h"
-#include "JSONAdapterTestUtilities/Mocks/MockJSONRemoteSchemaProvider.h"
-
 #include <string>
 
-using namespace testing;
-using namespace systelab::json::test_utility;
 
-namespace
-{
+namespace {
 	static const std::string basicJson =
-		"{								\n"
-		"	\"toBeRemoved\": 1,			\n"
-		"	\"filler1\" : \"filler1\",	\n"
-		"	\"filler2\" : \"filler2\",	\n"
-		"	\"last\" : \"last\"			\n"
-		"}								\n";
-
-	static const std::string nestedJson =
 		"{										\n"
+		"	\"toBeRemoved\": \"toBeRemoved\",	\n"
 		"	\"filler1\" : \"filler1\",			\n"
-		"	\"content\" : 						\n"
-		"	{									\n"
-		"		\"sub1\" : \"sub1\",			\n"
-		"		\"toBeRemoved\" : 1,			\n"
-		"		\"sub2\" : \"sub2\",			\n"
-		"		\"last\" : \"last\"				\n"
-		"	},									\n"
-		"	\"filler2\" : \"filler2\"			\n"
+		"	\"filler2\" : \"filler2\",			\n"
+		"	\"last\" : \"last\"					\n"
 		"}										\n";
 
+	static const std::string nestedJson =
+		"{											\n"
+		"	\"filler1\" : \"filler1\",				\n"
+		"	\"content\" : 							\n"
+		"	{										\n"
+		"		\"sub1\" : \"sub1\",				\n"
+		"		\"toBeRemoved\" : \"toBeRemoved\",	\n"
+		"		\"sub2\" : \"sub2\",				\n"
+		"		\"last\" : \"last\"					\n"
+		"	},										\n"
+		"	\"filler2\" : \"filler2\"				\n"
+		"}											\n";
 }
-
 
 namespace systelab::json::rapidjson::unit_test {
 
-	class JSONCustomTest : public testing::Test
+	class JSONValueRemoveTest : public testing::Test
 	{
 	protected:
 		JSONAdapter m_jsonAdapter;
 	};
 
-	TEST_F(JSONCustomTest, testRemoveMaintainsIntegrityOfWholeJSON)
+	TEST_F(JSONValueRemoveTest, testRemovedElementIsRemoved)
+	{
+		auto jsonDocument = m_jsonAdapter.buildDocumentFromString(basicJson);
+		auto& jsonRoot = jsonDocument->getRootValue();
+
+		jsonRoot.removeMember("toBeRemoved");
+
+		EXPECT_THROW(jsonRoot.getObjectMemberValue("toBeRemoved"), 
+					 std::runtime_error);
+	}
+
+	TEST_F(JSONValueRemoveTest, testRemoveInMainObjectMaintainsIntegrityOfWholeJSON)
 	{
 		auto jsonDocument = m_jsonAdapter.buildDocumentFromString(basicJson);
 		auto& jsonRoot = jsonDocument->getRootValue();
@@ -67,7 +69,7 @@ namespace systelab::json::rapidjson::unit_test {
 		EXPECT_EQ(filler2JSONValue.getString(), "filler2");
 	}
 
-	TEST_F(JSONCustomTest, testRemoveMaintainsIntegrityOfObject)
+	TEST_F(JSONValueRemoveTest, testRemoveNestedObjectMaintainsIntegrityOfObject)
 	{
 		auto jsonDocument = m_jsonAdapter.buildDocumentFromString(nestedJson);
 		auto& jsonRoot = jsonDocument->getRootValue();

--- a/test/RapidJSONAdapterTest/Tests/JSONValueRemoveTest.cpp
+++ b/test/RapidJSONAdapterTest/Tests/JSONValueRemoveTest.cpp
@@ -1,0 +1,94 @@
+#include "stdafx.h"
+#include "RapidJSONAdapter/JSONAdapter.h"
+
+#include "RapidJSONAdapter/JSONDocument.h"
+#include "RapidJSONAdapter/JSONValue.h"
+
+#include "JSONAdapterTestUtilities/JSONAdapterUtilities.h"
+#include "JSONAdapterTestUtilities/Mocks/MockJSONDocument.h"
+#include "JSONAdapterTestUtilities/Mocks/MockJSONRemoteSchemaProvider.h"
+
+#include <string>
+
+using namespace testing;
+using namespace systelab::json::test_utility;
+
+namespace
+{
+	static const std::string basicJson =
+		"{								\n"
+		"	\"toBeRemoved\": 1,			\n"
+		"	\"filler1\" : \"filler1\",	\n"
+		"	\"filler2\" : \"filler2\",	\n"
+		"	\"last\" : \"last\"			\n"
+		"}								\n";
+
+	static const std::string nestedJson =
+		"{										\n"
+		"	\"filler1\" : \"filler1\",			\n"
+		"	\"content\" : 						\n"
+		"	{									\n"
+		"		\"sub1\" : \"sub1\",			\n"
+		"		\"toBeRemoved\" : 1,			\n"
+		"		\"sub2\" : \"sub2\",			\n"
+		"		\"last\" : \"last\"				\n"
+		"	},									\n"
+		"	\"filler2\" : \"filler2\"			\n"
+		"}										\n";
+
+}
+
+
+namespace systelab::json::rapidjson::unit_test {
+
+	class JSONCustomTest : public testing::Test
+	{
+	protected:
+		JSONAdapter m_jsonAdapter;
+	};
+
+	TEST_F(JSONCustomTest, testRemoveMaintainsIntegrityOfWholeJSON)
+	{
+		auto jsonDocument = m_jsonAdapter.buildDocumentFromString(basicJson);
+		auto& jsonRoot = jsonDocument->getRootValue();
+
+		jsonRoot.removeMember("toBeRemoved");
+
+		auto& lastJSONValue = jsonRoot.getObjectMemberValue("last");
+		EXPECT_EQ(lastJSONValue.getType(), systelab::json::STRING_TYPE);
+		EXPECT_EQ(lastJSONValue.getString(), "last");
+
+		auto& filler1JSONValue = jsonRoot.getObjectMemberValue("filler1");
+		EXPECT_EQ(filler1JSONValue.getType(), systelab::json::STRING_TYPE);
+		EXPECT_EQ(filler1JSONValue.getString(), "filler1");
+
+		auto& filler2JSONValue = jsonRoot.getObjectMemberValue("filler2");
+		EXPECT_EQ(filler2JSONValue.getType(), systelab::json::STRING_TYPE);
+		EXPECT_EQ(filler2JSONValue.getString(), "filler2");
+	}
+
+	TEST_F(JSONCustomTest, testRemoveMaintainsIntegrityOfObject)
+	{
+		auto jsonDocument = m_jsonAdapter.buildDocumentFromString(nestedJson);
+		auto& jsonRoot = jsonDocument->getRootValue();
+		auto& jsonValueContent = jsonRoot.getObjectMemberValue("content");
+
+		jsonValueContent.removeMember("toBeRemoved");
+
+		auto& lastJSONValue = jsonValueContent.getObjectMemberValue("last");
+		EXPECT_EQ(lastJSONValue.getType(), systelab::json::STRING_TYPE);
+		EXPECT_EQ(lastJSONValue.getString(), "last");
+
+		auto& sub1JSONValue = jsonValueContent.getObjectMemberValue("sub1");
+		EXPECT_EQ(sub1JSONValue.getType(), systelab::json::STRING_TYPE);
+		EXPECT_EQ(sub1JSONValue.getString(), "sub1");
+
+		auto& sub2JSONValue = jsonValueContent.getObjectMemberValue("sub2");
+		EXPECT_EQ(sub2JSONValue.getType(), systelab::json::STRING_TYPE);
+		EXPECT_EQ(sub2JSONValue.getString(), "sub2");
+
+		auto& filler2JSONValue = jsonRoot.getObjectMemberValue("filler2");
+		EXPECT_EQ(filler2JSONValue.getType(), systelab::json::STRING_TYPE);
+		EXPECT_EQ(filler2JSONValue.getString(), "filler2");
+	}
+}


### PR DESCRIPTION
When rapidjson deletes a member of an object it swaps the member to delete with the last element of the object.
This invalidates the object the adapter was holding for the element that happens to be in last place in rapidjson's memory.

Fixed by also swaping the member to be deleted for the last member so no swap is actually performed. 

Added corresponding test.