### PR TITLE
Guard removeMember when item to be removed does not exist

### DIFF
--- a/src/RapidJSONAdapter/JSONValue.cpp
+++ b/src/RapidJSONAdapter/JSONValue.cpp
@@ -274,7 +274,12 @@ namespace systelab { namespace json { namespace rapidjson {
 
 			auto last = --(m_value.MemberEnd());
 			auto lastName = last->name.GetString();
-			m_objectMembers.find(name)->second.swap(m_objectMembers.find(lastName)->second);
+			auto toBeRemovedElement = m_objectMembers.find(name);
+			if (toBeRemovedElement == m_objectMembers.end())
+			{
+				return;
+			}
+			toBeRemovedElement->second.swap(m_objectMembers.find(lastName)->second);
 		}
 
 		m_value.RemoveMember(name);

--- a/src/RapidJSONAdapter/JSONValue.cpp
+++ b/src/RapidJSONAdapter/JSONValue.cpp
@@ -275,11 +275,10 @@ namespace systelab { namespace json { namespace rapidjson {
 			auto last = --(m_value.MemberEnd());
 			auto lastName = last->name.GetString();
 			auto toBeRemovedElement = m_objectMembers.find(name);
-			if (toBeRemovedElement == m_objectMembers.end())
+			if (toBeRemovedElement != m_objectMembers.end())
 			{
-				return;
+				toBeRemovedElement->second.swap(m_objectMembers.find(lastName)->second);
 			}
-			toBeRemovedElement->second.swap(m_objectMembers.find(lastName)->second);
 		}
 
 		m_value.RemoveMember(name);

--- a/test/RapidJSONAdapterTest/Tests/JSONValueRemoveTest.cpp
+++ b/test/RapidJSONAdapterTest/Tests/JSONValueRemoveTest.cpp
@@ -45,8 +45,7 @@ namespace systelab::json::rapidjson::unit_test {
 
 		jsonRoot.removeMember("toBeRemoved");
 
-		EXPECT_THROW(jsonRoot.getObjectMemberValue("toBeRemoved"), 
-					 std::runtime_error);
+		EXPECT_TRUE(jsonRoot.hasObjectMember("toBeRemoved"));
 	}
 
 	TEST_F(JSONValueRemoveTest, testRemoveInMainObjectMaintainsIntegrityOfWholeJSON)

--- a/test/RapidJSONAdapterTest/Tests/JSONValueRemoveTest.cpp
+++ b/test/RapidJSONAdapterTest/Tests/JSONValueRemoveTest.cpp
@@ -45,7 +45,7 @@ namespace systelab::json::rapidjson::unit_test {
 
 		jsonRoot.removeMember("toBeRemoved");
 
-		EXPECT_TRUE(jsonRoot.hasObjectMember("toBeRemoved"));
+		EXPECT_FALSE(jsonRoot.hasObjectMember("toBeRemoved"));
 	}
 
 	TEST_F(JSONValueRemoveTest, testRemoveInMainObjectMaintainsIntegrityOfWholeJSON)


### PR DESCRIPTION
Remove access to end of map when removing an element which is not present